### PR TITLE
Separated WebJobs into dedicated project / package

### DIFF
--- a/Moosesoft.Azure.Messaging.ServiceBus.sln
+++ b/Moosesoft.Azure.Messaging.ServiceBus.sln
@@ -1,0 +1,39 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33213.308
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moosesoft.Azure.Messaging.ServiceBus", "src\Moosesoft.Azure.Messaging.ServiceBus\Moosesoft.Azure.Messaging.ServiceBus.csproj", "{0F827E45-F1B2-47BF-8F55-004EE87AEB49}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moosesoft.Azure.Webjobs.Extensions.ServiceBus", "src\Moosesoft.Azure.Webjobs.Extensions.ServiceBus\Moosesoft.Azure.Webjobs.Extensions.ServiceBus.csproj", "{A12733DE-D7E2-4ED5-A7EA-1580E202C55E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C92BDFB0-712D-41D7-AFAE-0A0DAD157BB3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{AD70FA00-8CC3-45F3-B21A-274951FBA756}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0F827E45-F1B2-47BF-8F55-004EE87AEB49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F827E45-F1B2-47BF-8F55-004EE87AEB49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F827E45-F1B2-47BF-8F55-004EE87AEB49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F827E45-F1B2-47BF-8F55-004EE87AEB49}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A12733DE-D7E2-4ED5-A7EA-1580E202C55E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A12733DE-D7E2-4ED5-A7EA-1580E202C55E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A12733DE-D7E2-4ED5-A7EA-1580E202C55E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A12733DE-D7E2-4ED5-A7EA-1580E202C55E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0F827E45-F1B2-47BF-8F55-004EE87AEB49} = {C92BDFB0-712D-41D7-AFAE-0A0DAD157BB3}
+		{A12733DE-D7E2-4ED5-A7EA-1580E202C55E} = {C92BDFB0-712D-41D7-AFAE-0A0DAD157BB3}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C5BB8E90-E88A-4E14-B21F-D297DE533C94}
+	EndGlobalSection
+EndGlobal

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/BuilderState.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/BuilderState.cs
@@ -1,0 +1,14 @@
+﻿using Moosesoft.Azure.Messaging.ServiceBus.DelayCalculatorStrategies;
+using Moosesoft.Azure.Messaging.ServiceBus.FailurePolicies;
+using System;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.Builder;
+
+internal class BuilderState
+{
+    public IDelayCalculatorStrategy DelayCalculatorStrategy { get; set; }
+    public Func<IFailurePolicy> FailurePolicyFactory { get; set; }
+    public Type FailurePolicyType { get; set; }
+    public Func<Exception, bool> CanHandle { get; set; }
+    public IMessageProcessor MessageProcessor { get; set; }
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/IDelayCalculatorStrategyHolder.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/IDelayCalculatorStrategyHolder.cs
@@ -1,0 +1,71 @@
+﻿using Moosesoft.Azure.Messaging.ServiceBus.DelayCalculatorStrategies;
+using System;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.Abstractions.Builder;
+
+/// <summary>
+/// Provides a holding mechanism for instances of <see cref="IDelayCalculatorStrategy"/> to help constructing message pumps.
+/// </summary>
+public interface IDelayCalculatorStrategyHolder
+{
+    /// <summary>
+    /// Sets the instance of <see cref="IDelayCalculatorStrategy"/> for the message pump builder to use.
+    /// </summary>
+    /// <typeparam name="TStrategy">Type of <see cref="IDelayCalculatorStrategy"/></typeparam>
+    /// <param name="delayCalculatorStrategy"><see cref="IDelayCalculatorStrategy"/> to use for the use for the message pump builder.</param>
+    /// <returns>A message pump builder.</returns>
+    IMessageContextProcessorBuilder WithDelayCalculatorStrategy<TStrategy>(TStrategy delayCalculatorStrategy)
+        where TStrategy : IDelayCalculatorStrategy;
+
+    /// <summary>
+    /// Sets the instance of <see cref="IDelayCalculatorStrategy"/> for the message pump builder to use.
+    /// </summary>
+    /// <returns>A message pump builder.</returns>
+    IMessageContextProcessorBuilder WithDelayCalculatorStrategy<TStrategy>()
+        where TStrategy : IDelayCalculatorStrategy, new();
+
+    /// <summary>
+    /// Sets the instance of <see cref="IDelayCalculatorStrategy"/> to <see cref="ExponentialDelayCalculatorStrategy"/> for the message pump builder to use.
+    /// </summary>
+    /// <returns>A message pump builder.</returns>
+    IMessageContextProcessorBuilder WithExponentialDelayCalculatorStrategy();
+
+    /// <summary>
+    /// Sets the instance of <see cref="IDelayCalculatorStrategy"/> to <see cref="ExponentialDelayCalculatorStrategy"/> for the message pump builder to use.
+    /// </summary>
+    /// <param name="maxDelay">Maximum amount of time this strategy will return.</param>
+    /// <returns>A message pump builder.</returns>
+    IMessageContextProcessorBuilder WithExponentialDelayCalculatorStrategy(TimeSpan maxDelay);
+
+    /// <summary>
+    /// Sets the instance of <see cref="IDelayCalculatorStrategy"/> to <see cref="FixedDelayCalculatorStrategy"/> for the message pump builder to use.
+    /// </summary>
+    /// <returns>A message pump builder.</returns>
+    IMessageContextProcessorBuilder WithFixedDelayCalculatorStrategy();
+
+    /// <summary>
+    /// Sets the instance of <see cref="IDelayCalculatorStrategy"/> to <see cref="FixedDelayCalculatorStrategy"/> for the message pump builder to use.
+    /// </summary>
+    /// <param name="delayTime">Fixed amount of time which will be returned.</param>
+    /// <returns>A message pump builder.</returns>
+    IMessageContextProcessorBuilder WithFixedDelayCalculatorStrategy(TimeSpan delayTime);
+
+    /// <summary>
+    /// Sets the instance of <see cref="IDelayCalculatorStrategy"/> to <see cref="LinearDelayCalculatorStrategy"/> for the message pump builder to use.
+    /// </summary>
+    /// <returns>A message pump builder.</returns>
+    IMessageContextProcessorBuilder WithLinearDelayCalculatorStrategy();
+
+    /// <summary>
+    /// Sets the instance of <see cref="IDelayCalculatorStrategy"/> to <see cref="LinearDelayCalculatorStrategy"/> for the message pump builder to use.
+    /// </summary>
+    /// <param name="delayTime">Amount of time to use with attempt multiplier.</param>
+    /// <returns>A message pump builder.</returns>
+    IMessageContextProcessorBuilder WithLinearDelayCalculatorStrategy(TimeSpan delayTime);
+
+    /// <summary>
+    /// Sets the instance of <see cref="IDelayCalculatorStrategy"/> to <see cref="ZeroDelayCalculatorStrategy"/> for the message pump builder to use.
+    /// </summary>
+    /// <returns>A message pump builder.</returns>
+    IMessageContextProcessorBuilder WithZeroDelayCalculatorStrategy();
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/IFailurePolicyHolder.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/IFailurePolicyHolder.cs
@@ -1,0 +1,33 @@
+﻿using Moosesoft.Azure.Messaging.ServiceBus.FailurePolicies;
+using System;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.Abstractions.Builder;
+
+/// <summary>
+/// Provides a holding mechanism for instances of <see cref="IFailurePolicy"/> to help constructing message pumps.
+/// </summary>
+public interface IFailurePolicyHolder
+{
+    /// <summary>
+    /// Sets the instance of <see cref="IFailurePolicy"/> to <see cref="CloneMessageFailurePolicy"/> for the message pump builder to use.
+    /// </summary>
+    /// <param name="canHandle">Function providing <see cref="bool"/> for which exceptions should be handled by the <see cref="IFailurePolicy"/>.</param>
+    /// <returns><see cref="IDelayCalculatorStrategyHolder"/></returns>
+    IDelayCalculatorStrategyHolder WithCloneMessageFailurePolicy(Func<Exception, bool> canHandle = null, int maxMessageDeliveryCount = 10);
+
+
+    /// <summary>
+    /// Sets the instance of <see cref="IFailurePolicy"/> to <see cref="AbandonMessageFailurePolicy"/> for the message pump builder to use.
+    /// </summary>
+    /// <returns>A message pump builder</returns>
+    IMessageContextProcessorBuilder WithAbandonMessageFailurePolicy();
+
+    /// <summary>
+    /// Sets the instance of <see cref="IFailurePolicy"/> for the message pump builder to use.
+    /// </summary>
+    /// <typeparam name="TFailurePolicy">Type of <see cref="IFailurePolicy"/></typeparam>
+    /// <param name="failurePolicy"><see cref="IFailurePolicy"/> to use for the use for the message pump builder.</param>
+    /// <returns>A message pump builder</returns>
+    IMessageContextProcessorBuilder WithFailurePolicy<TFailurePolicy>(TFailurePolicy failurePolicy)
+        where TFailurePolicy : IFailurePolicy;
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/IMessageContextProcessorBuilder.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/IMessageContextProcessorBuilder.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.Abstractions.Builder;
+
+/// <summary>
+/// Defines a builder for creating instances of <see cref="IMessageContextProcessor"/>.
+/// </summary>
+public interface IMessageContextProcessorBuilder
+{
+    /// <summary>
+    /// Build a new <see cref="IMessageContextProcessor"/>.
+    /// </summary>
+    /// <param name="shouldCompleteOn">Optional parameter that allows you to complete certain exceptions without applying failure policies.</param>
+    /// <returns><see cref="IMessageContextProcessor"/></returns>
+    IMessageContextProcessor Build(Func<Exception, bool> shouldCompleteOn = null);
+
+    IMessageContextProcessor Build(string name, Func<Exception, bool> shouldCompleteOn = null);
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/IMessageProcessorHolder.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/IMessageProcessorHolder.cs
@@ -1,0 +1,35 @@
+﻿using Azure.Messaging.ServiceBus;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.Abstractions.Builder;
+
+/// <summary>
+/// Interface that defines a set of methods for specifying different implementations of <see cref="IMessageProcessor"/>.
+/// </summary>
+public interface IMessageProcessorHolder
+{
+    /// <summary>
+    /// Set an instance of <see cref="IMessageProcessor"/> to be used for configuration.
+    /// </summary>
+    /// <param name="messageProcessor"><see cref="IMessageProcessor"/> instance to be used.</param>
+    /// <typeparam name="TProcessor">Type of <see cref="IMessageProcessor"/></typeparam>
+    /// <returns><see cref="IFailurePolicyHolder"/></returns>
+    IFailurePolicyHolder WithMessageProcessor<TProcessor>(TProcessor messageProcessor)
+        where TProcessor : IMessageProcessor;
+
+    /// <summary>
+    /// Set an instance of <see cref="IMessageProcessor"/> to be used for configuration.
+    /// </summary>
+    /// <typeparam name="TProcessor">Type of <see cref="IMessageProcessor"/></typeparam>
+    /// <returns><see cref="IFailurePolicyHolder"/></returns>
+    IFailurePolicyHolder WithMessageProcessor<TProcessor>()
+        where TProcessor : IMessageProcessor, new();
+
+    /// <summary>
+    /// Set a function pointer for message processing to be used for configuration instead of an instance of <see cref="IMessageProcessor"/>.
+    /// </summary>
+    /// <returns><see cref="IFailurePolicyHolder"/></returns>
+    IFailurePolicyHolder WithMessageProcessor(Func<ServiceBusReceivedMessage, CancellationToken, Task> processMessage);
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/MessageContextProcessorBuilder.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/Builder/MessageContextProcessorBuilder.cs
@@ -1,0 +1,147 @@
+﻿using Azure.Messaging.ServiceBus;
+using Moosesoft.Azure.Messaging.ServiceBus.Builder;
+using Moosesoft.Azure.Messaging.ServiceBus.DelayCalculatorStrategies;
+using Moosesoft.Azure.Messaging.ServiceBus.FailurePolicies;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.Abstractions.Builder;
+
+public class MessageContextProcessorBuilder 
+    : IMessageProcessorHolder, IFailurePolicyHolder, IDelayCalculatorStrategyHolder, IMessageContextProcessorBuilder
+{
+    private readonly ServiceBusEntityDescription _serviceBusEntityDescription;
+    private readonly BuilderState _state;
+
+    private MessageContextProcessorBuilder(ServiceBusEntityDescription serviceBusEntityDescription)
+    {
+        _serviceBusEntityDescription = serviceBusEntityDescription ?? throw new ArgumentNullException(nameof(serviceBusEntityDescription));
+        _state = new BuilderState();
+    }
+
+    public static IMessageProcessorHolder Configure(ServiceBusEntityDescription serviceBusEntityDescription)
+        => new MessageContextProcessorBuilder(serviceBusEntityDescription);
+
+    public IFailurePolicyHolder WithMessageProcessor<TProcessor>(TProcessor messageProcessor) where TProcessor : IMessageProcessor
+    {
+        if (messageProcessor == null) throw new ArgumentNullException(nameof(messageProcessor));
+
+        _state.MessageProcessor = messageProcessor;
+        return this;
+    }
+
+    public IFailurePolicyHolder WithMessageProcessor<TProcessor>() where TProcessor : IMessageProcessor, new()
+    {
+        return WithMessageProcessor(new TProcessor());
+    }
+
+    public IFailurePolicyHolder WithMessageProcessor(Func<ServiceBusReceivedMessage, CancellationToken, Task> processMessage)
+    {
+        return WithMessageProcessor(new FuncMessageProcessor(processMessage));
+    }
+
+    public IDelayCalculatorStrategyHolder WithCloneMessageFailurePolicy(Func<Exception, bool> canHandle = null, int maxMessageDeliveryCount = 10)
+    {
+        _state.FailurePolicyFactory = () => new CloneMessageFailurePolicy(canHandle, _state.DelayCalculatorStrategy, maxMessageDeliveryCount);
+        return this;
+    }
+
+    public IMessageContextProcessorBuilder WithAbandonMessageFailurePolicy()
+    {
+        return WithFailurePolicy(new AbandonMessageFailurePolicy());
+    }
+
+    public IMessageContextProcessorBuilder WithFailurePolicy<TFailurePolicy>(TFailurePolicy failurePolicy) 
+        where TFailurePolicy : IFailurePolicy
+    {
+        if (failurePolicy == null) throw new ArgumentNullException(nameof(failurePolicy));
+
+        _state.FailurePolicyFactory = () => failurePolicy;
+        return this;
+    }
+    
+    public IMessageContextProcessorBuilder WithDelayCalculatorStrategy<TStrategy>(TStrategy delayCalculatorStrategy) 
+        where TStrategy : IDelayCalculatorStrategy
+    {
+        if (delayCalculatorStrategy == null) throw new ArgumentNullException(nameof(delayCalculatorStrategy));
+
+        _state.DelayCalculatorStrategy = delayCalculatorStrategy;
+        return this;
+    }
+
+    public IMessageContextProcessorBuilder WithDelayCalculatorStrategy<TStrategy>() 
+        where TStrategy : IDelayCalculatorStrategy, new()
+    {
+        return WithDelayCalculatorStrategy(new TStrategy());
+    }
+
+    public IMessageContextProcessorBuilder WithExponentialDelayCalculatorStrategy()
+    {
+        return WithDelayCalculatorStrategy(ExponentialDelayCalculatorStrategy.Default);
+    }
+
+    public IMessageContextProcessorBuilder WithExponentialDelayCalculatorStrategy(TimeSpan maxDelay)
+    {
+        return WithDelayCalculatorStrategy(new ExponentialDelayCalculatorStrategy(maxDelay));
+    }
+
+    public IMessageContextProcessorBuilder WithFixedDelayCalculatorStrategy()
+    {
+        return WithDelayCalculatorStrategy(FixedDelayCalculatorStrategy.Default);
+    }
+
+    public IMessageContextProcessorBuilder WithFixedDelayCalculatorStrategy(TimeSpan delayTime)
+    {
+        return WithDelayCalculatorStrategy(new FixedDelayCalculatorStrategy(delayTime));
+    }
+
+    public IMessageContextProcessorBuilder WithLinearDelayCalculatorStrategy()
+    {
+        return WithDelayCalculatorStrategy(LinearDelayCalculatorStrategy.Default);
+    }
+
+    public IMessageContextProcessorBuilder WithLinearDelayCalculatorStrategy(TimeSpan delayTime)
+    {
+        return WithDelayCalculatorStrategy(new LinearDelayCalculatorStrategy(delayTime));
+    }
+
+    public IMessageContextProcessorBuilder WithZeroDelayCalculatorStrategy()
+    {
+        return WithDelayCalculatorStrategy(new ZeroDelayCalculatorStrategy());
+    }
+
+    public IMessageContextProcessor Build(Func<Exception, bool> shouldCompleteOn = null)
+    {
+        return new ServiceBusReceivedMessageContextProcessor(
+            _serviceBusEntityDescription, 
+            _state.MessageProcessor,
+            _state.FailurePolicyFactory(), 
+            shouldCompleteOn);
+    }
+
+    public IMessageContextProcessor Build(string name, Func<Exception, bool> shouldCompleteOn = null)
+    {
+        return new ServiceBusReceivedMessageContextProcessor(
+            _serviceBusEntityDescription,
+            _state.MessageProcessor,
+            _state.FailurePolicyFactory(),
+            shouldCompleteOn, 
+            name);
+    }
+}
+
+class MyClass
+{
+
+    void foo()
+    {
+        MessageContextProcessorBuilder
+            .Configure(new ServiceBusEntityDescription("queue"))
+            .WithMessageProcessor((message, token) => Task.CompletedTask)
+            .WithCloneMessageFailurePolicy(ex => ex is InvalidOperationException)
+            .WithFixedDelayCalculatorStrategy(TimeSpan.FromMinutes(10))
+            .Build("ProcessorName", ex => ex is NotSupportedException);
+            
+    }
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/Constants.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/Constants.cs
@@ -1,0 +1,6 @@
+﻿namespace Moosesoft.Azure.Messaging.ServiceBus;
+
+internal static class Constants
+{
+    public const string RetryCountKey = "retry-count";
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/DelayCalculatorStrategies/ExponentialDelayCalculatorStrategy.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/DelayCalculatorStrategies/ExponentialDelayCalculatorStrategy.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.DelayCalculatorStrategies;
+
+/// <summary>
+/// This delay calculator strategy uses an exponential model to calculate delays.
+/// </summary>
+public class ExponentialDelayCalculatorStrategy : IDelayCalculatorStrategy
+{
+    private static readonly TimeSpan DefaultMaxDelayTime = TimeSpan.FromMinutes(60);
+
+    private static readonly TimeSpan DefaultInitialDelay = TimeSpan.FromSeconds(100);
+
+    private readonly TimeSpan _maxDelay;
+
+    private readonly int _initialBackOffDelaySeconds;
+
+    /// <summary>
+    /// Initialize a new instance <see cref="ExponentialDelayCalculatorStrategy"/>.
+    /// </summary>
+    /// <param name="maxDelayTime"></param>
+    public ExponentialDelayCalculatorStrategy(TimeSpan maxDelayTime) : this(maxDelayTime, DefaultInitialDelay)
+    {
+
+    }
+
+    /// <summary>
+    /// Initialize a new instance <see cref="ExponentialDelayCalculatorStrategy"/>.
+    /// </summary>
+    /// <param name="maxDelayTime">The maximum back off that would be calculated</param>
+    /// <param name="initialDelay">The initial back off</param>
+    public ExponentialDelayCalculatorStrategy(TimeSpan maxDelayTime, TimeSpan initialDelay)
+    {
+        _maxDelay = maxDelayTime > TimeSpan.Zero ? maxDelayTime : DefaultMaxDelayTime;
+        _initialBackOffDelaySeconds = (int)(initialDelay > TimeSpan.Zero ? initialDelay : DefaultInitialDelay).TotalSeconds;
+    }
+
+    /// <inheritdoc cref="IDelayCalculatorStrategy"/>
+    public virtual TimeSpan Calculate(int attempts)
+        => new[] { TimeSpan.FromSeconds(_initialBackOffDelaySeconds * Math.Pow(attempts, 2)), _maxDelay }.Min();
+
+    /// <summary>
+    /// Creates an instance of this delay calculator strategy with default settings.
+    /// </summary>
+    public static readonly IDelayCalculatorStrategy Default = new ExponentialDelayCalculatorStrategy(DefaultMaxDelayTime);
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/DelayCalculatorStrategies/FixedDelayCalculatorStrategy.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/DelayCalculatorStrategies/FixedDelayCalculatorStrategy.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.DelayCalculatorStrategies;
+
+/// <summary>
+/// This strategy provides a constant delay for every Calculate call regardless of attempt count.
+/// </summary>
+public class FixedDelayCalculatorStrategy : IDelayCalculatorStrategy
+{
+    private static readonly TimeSpan DefaultDelayTimeSpan = TimeSpan.FromMinutes(5);
+
+    private readonly TimeSpan _delay;
+
+    /// <summary>
+    /// Initialize a new instance <see cref="FixedDelayCalculatorStrategy"/>.
+    /// </summary>
+    /// <param name="delayTimeSpan">Fixed TimeSpan returned always when this strategy is asked to calculate new delay.</param>
+    public FixedDelayCalculatorStrategy(TimeSpan delayTimeSpan)
+    {
+        _delay = delayTimeSpan >= TimeSpan.Zero ? delayTimeSpan : DefaultDelayTimeSpan;
+    }
+
+    /// <inheritdoc cref="IDelayCalculatorStrategy"/>
+    public TimeSpan Calculate(int attempts) => _delay;
+
+    /// <summary>
+    /// Creates an instance of this delay calculator strategy with default settings.
+    /// </summary>
+    public static IDelayCalculatorStrategy Default => new FixedDelayCalculatorStrategy(DefaultDelayTimeSpan);
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/DelayCalculatorStrategies/IDelayCalculatorStrategy.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/DelayCalculatorStrategies/IDelayCalculatorStrategy.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.DelayCalculatorStrategies;
+
+/// <summary>
+/// Defines a strategy for calculating delay for message processing retries.
+/// </summary>
+public interface IDelayCalculatorStrategy
+{
+    /// <summary>
+    /// Performs calculation to determine how much time to wait for next retry.
+    /// </summary>
+    /// <param name="attempts">The number of attempts to process the message.</param>
+    /// <returns>Delay that should be applied to the message before it is retried.</returns>
+    TimeSpan Calculate(int attempts);
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/DelayCalculatorStrategies/LinearDelayCalculatorStrategy.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/DelayCalculatorStrategies/LinearDelayCalculatorStrategy.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.DelayCalculatorStrategies;
+
+/// <summary>
+/// This strategy performs back off delay calculations using a linear model.
+/// </summary>
+public class LinearDelayCalculatorStrategy : IDelayCalculatorStrategy
+{
+    private readonly TimeSpan _initialDelay;
+
+    /// <summary>
+    /// Initialize a new instance <see cref="LinearDelayCalculatorStrategy"/>.
+    /// </summary>
+    /// <param name="initialDelay"></param>
+    public LinearDelayCalculatorStrategy(TimeSpan initialDelay)
+    {
+        _initialDelay = initialDelay;
+    }
+
+    /// <inheritdoc cref="IDelayCalculatorStrategy"/>
+    public virtual TimeSpan Calculate(int attempts) => TimeSpan.FromSeconds(_initialDelay.TotalSeconds * attempts);
+
+    /// <summary>
+    /// Creates an instance of this delay calculator strategy with default settings.
+    /// </summary>
+    public static IDelayCalculatorStrategy Default => new LinearDelayCalculatorStrategy(TimeSpan.FromMinutes(1));
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/DelayCalculatorStrategies/ZeroDelayCalculatorStrategy.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/DelayCalculatorStrategies/ZeroDelayCalculatorStrategy.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.DelayCalculatorStrategies;
+
+/// <summary>
+/// This strategy will always calculate a zero delay.
+/// </summary>
+public class ZeroDelayCalculatorStrategy : FixedDelayCalculatorStrategy
+{
+    /// <summary>
+    /// Creates a new instance of this delay calculator strategy.
+    /// </summary>
+    public ZeroDelayCalculatorStrategy() : base(TimeSpan.Zero)
+    {
+    }
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/FailurePolicies/AbandonMessageFailurePolicy.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/FailurePolicies/AbandonMessageFailurePolicy.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.FailurePolicies;
+
+/// <summary>
+/// This failure policy will abandon the message for any exceptions that occur without any back off delay.
+/// </summary>
+public class AbandonMessageFailurePolicy : FailurePolicyBase
+{
+    /// <summary>
+    /// Initialize a new instance <see cref="AbandonMessageFailurePolicy"/>.
+    /// </summary>
+    public AbandonMessageFailurePolicy() : base(_ => false)
+    {
+    }
+
+    /// <inheritdoc />
+    public override Task HandleFailureAsync(IServiceBusReceivedMessageContext messageContext, CancellationToken cancellationToken)
+        => Task.CompletedTask;
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/FailurePolicies/CloneMessageFailurePolicy.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/FailurePolicies/CloneMessageFailurePolicy.cs
@@ -1,0 +1,70 @@
+﻿using Azure.Messaging.ServiceBus;
+using Moosesoft.Azure.Messaging.ServiceBus.DelayCalculatorStrategies;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.FailurePolicies;
+
+/// <summary>
+/// This failure policy will create a clone of the Service Bus Message attempting to be processed.
+/// The clone will then be sent back to Service Bus while the original message is completed in an atomic transaction with the send.
+/// New messages sent to Service Bus will be delayed based upon the <see cref="IDelayCalculatorStrategy"/> chosen.
+/// </summary>
+public class CloneMessageFailurePolicy : FailurePolicyBase
+{
+    /// <inheritdoc />
+    public CloneMessageFailurePolicy(
+        Func<Exception, bool> canHandle,
+        IDelayCalculatorStrategy delayCalculatorStrategy = null,
+        int maxDeliveryCount = 10)
+        : base(canHandle, delayCalculatorStrategy, maxDeliveryCount)
+    {
+    }
+
+    /// <inheritdoc />
+    public override async Task HandleFailureAsync(IServiceBusReceivedMessageContext messageContext, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var deliveryCount = GetDeliveryCount(messageContext.Message);
+        if (deliveryCount >= MaxDeliveryCount)
+        {
+            await messageContext
+                .DeadLetterMessageAsync(messageContext.Message, $"Max delivery count of {MaxDeliveryCount} has been reached.", cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+
+            return;
+        }
+
+        var clone = new ServiceBusMessage(messageContext.Message)
+        {
+            MessageId = Guid.NewGuid().ToString(),
+            ScheduledEnqueueTime = DateTime.UtcNow + DelayCalculatorStrategy.Calculate(deliveryCount),
+            ApplicationProperties =
+            {
+                [Constants.RetryCountKey] = deliveryCount
+            }
+        };
+
+        var sender = messageContext.CreateMessageSender(ServiceBusEntityDescription);
+        try
+        {
+            using var scope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+            await sender.SendMessageAsync(clone, cancellationToken).ConfigureAwait(false);
+            await messageContext
+                .CompleteMessageAsync(messageContext.Message, cancellationToken)
+                .ConfigureAwait(false);
+
+            scope.Complete();
+        }
+        finally
+        {
+            await sender.CloseAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override int GetDeliveryCount(ServiceBusReceivedMessage message) => base.GetDeliveryCount(message) + message.GetRetryCount();
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/FailurePolicies/FailurePolicyBase.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/FailurePolicies/FailurePolicyBase.cs
@@ -1,0 +1,57 @@
+﻿using Azure.Messaging.ServiceBus;
+using Moosesoft.Azure.Messaging.ServiceBus.DelayCalculatorStrategies;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.FailurePolicies;
+
+/// <inheritdoc cref="IFailurePolicy"/>>
+public abstract class FailurePolicyBase : IFailurePolicy
+{
+    /// <summary>
+    /// Maximum delivery count allowed
+    /// </summary>
+    protected int MaxDeliveryCount { get; }
+
+    /// <summary>
+    /// Back off delay calculator strategy
+    /// </summary>
+    protected IDelayCalculatorStrategy DelayCalculatorStrategy { get; }
+
+    protected ServiceBusEntityDescription ServiceBusEntityDescription { get; private set; }
+
+    private readonly Func<Exception, bool> _canHandle;
+    
+    /// <summary>
+    /// Initialize a new instance <see cref="IFailurePolicy"/>.
+    /// </summary>
+    /// <param name="canHandle">Function that determines if the exception that has occurred <see cref="IFailurePolicy"/> will be applied to it.</param>
+    /// <param name="delayCalculatorStrategy"><see cref="IDelayCalculatorStrategy"/> to use when <see cref="IFailurePolicy"/> is applied.</param>
+    /// <param name="maxDeliveryCount">Maximum number of message delivery counts from Azure Service Bus.</param>
+    protected FailurePolicyBase(Func<Exception, bool> canHandle, IDelayCalculatorStrategy delayCalculatorStrategy = null, int maxDeliveryCount = 10)
+    {
+        _canHandle = canHandle ?? throw new ArgumentNullException(nameof(canHandle));
+        DelayCalculatorStrategy = delayCalculatorStrategy ?? new ZeroDelayCalculatorStrategy();
+        MaxDeliveryCount = maxDeliveryCount >= 0 ? maxDeliveryCount : 10;
+    }
+
+    /// <inheritdoc />
+    public bool CanHandle(Exception exception) => _canHandle(exception);
+
+    /// <inheritdoc />
+    public abstract Task HandleFailureAsync(IServiceBusReceivedMessageContext messageContext, CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    public void SetEntityDescription(ServiceBusEntityDescription description)
+    {
+        ServiceBusEntityDescription = description ?? throw new ArgumentNullException(nameof(description));
+    }
+
+    /// <summary>
+    /// Gets the delivery count for the specified Service Bus <see cref="ServiceBusReceivedMessage"/>.
+    /// </summary>
+    /// <param name="message">Message used to determine the delivery count.</param>
+    /// <returns>Number of times the message has been delivered.</returns>
+    protected virtual int GetDeliveryCount(ServiceBusReceivedMessage message) => message.GetDeliveryCount();
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/FailurePolicies/IFailurePolicy.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/FailurePolicies/IFailurePolicy.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus.FailurePolicies;
+
+/// <summary>
+/// Defines a failure policy which describes how to handle message processing failures.
+/// </summary>
+public interface IFailurePolicy
+{
+    /// <summary>
+    /// Determines whether the type of exception that has occurred should be handled
+    /// </summary>
+    /// <param name="exception">Exception that has occurred while processing a message.</param>
+    /// <returns>A <see cref="bool"/> which indicates whether to handle this exception or not.</returns>
+    bool CanHandle(Exception exception);
+
+    /// <summary>
+    /// Handles Service Bus Message processing failures
+    /// </summary>
+    /// <param name="messageContext">The context the Service Bus Message resides in.</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns><see cref="Task"/></returns>
+    Task HandleFailureAsync(IServiceBusReceivedMessageContext messageContext, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sets the description of the Service Bus entity for which the failure policy should be applied.
+    /// </summary>
+    /// <param name="description">Description of the Service Bus entity, queue or topic and subscription.</param>
+    void SetEntityDescription(ServiceBusEntityDescription description);
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/FuncMessageProcessor.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/FuncMessageProcessor.cs
@@ -1,0 +1,20 @@
+﻿using Azure.Messaging.ServiceBus;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus;
+
+internal class FuncMessageProcessor : IMessageProcessor
+{
+    private readonly Func<ServiceBusReceivedMessage, CancellationToken, Task> _processMessage;
+
+    public FuncMessageProcessor(Func<ServiceBusReceivedMessage, CancellationToken, Task> processMessage)
+    {
+        _processMessage = processMessage ?? throw new ArgumentNullException(nameof(processMessage));
+    }
+
+    public Task ProcessMessageAsync(ServiceBusReceivedMessage message, CancellationToken cancellationToken) 
+        => _processMessage(message, cancellationToken);
+
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/IMessageContextProcessor.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/IMessageContextProcessor.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus;
+
+/// <summary>
+/// Defines an object that processes a <see cref="ServiceBusReceivedMessageContext"/>
+/// </summary>
+public interface IMessageContextProcessor
+{
+    /// <summary>
+    /// Optional name for the MessageContextProcessor. By default is "default"
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Processes the received <see cref="ServiceBusReceivedMessageContext"/>
+    /// </summary>
+    /// <param name="messageContext">Context to be processed.</param>
+    /// <param name="cancellationToken">Optional cancellation token provided to check for cancellation upstream.</param>
+    /// <returns><see cref="Task"/></returns>
+    Task ProcessMessageContextAsync(IServiceBusReceivedMessageContext messageContext, CancellationToken cancellationToken = default);
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/IMessageProcessor.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/IMessageProcessor.cs
@@ -1,0 +1,19 @@
+﻿using Azure.Messaging.ServiceBus;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus;
+
+/// <summary>
+/// Defines an object that processes a Service Bus <see cref="ServiceBusReceivedMessage"/>
+/// </summary>
+public interface IMessageProcessor
+{
+    /// <summary>
+    /// Processes a Service Bus <see cref="ServiceBusReceivedMessage"/>
+    /// </summary>
+    /// <param name="message">Message received from a Service Bus entity for processing.</param>
+    /// <param name="cancellationToken">Cancellation token used to check for cancellation upstream.</param>
+    /// <returns><see cref="Task"/></returns>
+    Task ProcessMessageAsync(ServiceBusReceivedMessage message, CancellationToken cancellationToken);
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/IServiceBusReceivedMessageContext.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/IServiceBusReceivedMessageContext.cs
@@ -1,0 +1,51 @@
+﻿using Azure.Messaging.ServiceBus;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus;
+
+/// <summary>
+/// 
+/// </summary>
+public interface IServiceBusReceivedMessageContext
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public ServiceBusReceivedMessage Message { get; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="description"></param>
+    /// <returns></returns>
+    ServiceBusSender CreateMessageSender(ServiceBusEntityDescription description);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="reason"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task DeadLetterMessageAsync(ServiceBusReceivedMessage message, string reason, CancellationToken cancellationToken);
+
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task CompleteMessageAsync(ServiceBusReceivedMessage message, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="propertiesToModify"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task AbandonMessageAsync(ServiceBusReceivedMessage message, IDictionary<string, object> propertiesToModify = null, CancellationToken cancellationToken = default);
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/InternalsVisibleTo.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/InternalsVisibleTo.cs
@@ -1,0 +1,2 @@
+﻿using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Moosesoft.Azure.Messaging.ServiceBus.Tests")]

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/Moosesoft.Azure.Messaging.ServiceBus.csproj
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/Moosesoft.Azure.Messaging.ServiceBus.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RootNamespace>Moosesoft.Azure.Messaging.ServiceBus</RootNamespace>
+		<LangVersion>latest</LangVersion>
+		<Version>1.0.0-preview1</Version>
+		<Authors>Marty Mathis</Authors>
+		<Company />
+		<Description>Provides support for advanced message processing scenarios using Microsoft Azure Service Bus, including retry with back off delay handling through failure policies.</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/gtmoose32/moosesoft-azure-messing-servicebus</PackageProjectUrl>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/gtmoose32/moosesoft-azure-messaging-servicebus</RepositoryUrl>
+		<PackageTags>azure servicebus service bus retry delay backoff message queue topic</PackageTags>
+		<NeutralLanguage>en-US</NeutralLanguage>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<DocumentationFile Condition="'$(Configuration)'=='Release'">bin\Release\netstandard2.0\Moosesoft.Azure.Messaging.ServiceBus.xml</DocumentationFile>
+		<PackageReleaseNotes>
+		</PackageReleaseNotes>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.12.0" />
+	</ItemGroup>
+
+</Project>

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/Moosesoft.Azure.Webjobs.Extensions.ServiceBus.csproj
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/Moosesoft.Azure.Webjobs.Extensions.ServiceBus.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Moosesoft.Azure.Webjobs.Extensions.ServiceBus</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <Version>1.0.0-preview1</Version>
+    <Authors>Marty Mathis</Authors>
+    <Company />
+    <Description>Provides support for advanced message processing scenarios using Microsoft Azure Service Bus, including retry with back off delay handling through failure policies.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/gtmoose32/moosesoft-azure-messaging-servicebus</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/gtmoose32/moosesoft-azure-messaging-servicebus</RepositoryUrl>
+    <PackageTags>azure function webjob servicebus service bus retry delay backoff message queue topic</PackageTags>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <DocumentationFile Condition="'$(Configuration)'=='Release'">bin\Release\netstandard2.0\Moosesoft.Azure.Messaging.ServiceBus.xml</DocumentationFile>
+    <PackageReleaseNotes>
+    </PackageReleaseNotes>
+
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.8.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/ServiceBusEntityDescription.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/ServiceBusEntityDescription.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus;
+
+public class ServiceBusEntityDescription
+{
+    private readonly string _entityName;
+
+    public string QueueName => IsQueue() ? _entityName : null;
+
+    public string TopicName => !IsQueue() ? _entityName : null;
+
+    public string SubscriptionName { get; }
+
+    public ServiceBusEntityDescription(string queueName)
+    {
+        if (string.IsNullOrWhiteSpace(queueName))
+            throw new ArgumentException("Cannot be null, empty or whitespace.", nameof(queueName));
+
+        _entityName = queueName;
+    }
+
+    public ServiceBusEntityDescription(string topicName, string subscriptionName)
+    {
+        if (string.IsNullOrWhiteSpace(topicName))
+            throw new ArgumentException("Cannot be null, empty or whitespace.", nameof(topicName));
+
+        if (string.IsNullOrWhiteSpace(subscriptionName))
+            throw new ArgumentException("Cannot be null, empty or whitespace.", nameof(subscriptionName));
+
+        _entityName = topicName;
+        SubscriptionName = subscriptionName;
+    }
+
+    public bool IsQueue() => SubscriptionName == null;
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/ServiceBusReceivedMessageContext.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/ServiceBusReceivedMessageContext.cs
@@ -1,0 +1,58 @@
+﻿using Azure.Messaging.ServiceBus;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus;
+
+/// <inheritdoc />
+public class ServiceBusReceivedMessageContext : IServiceBusReceivedMessageContext
+{
+    private readonly ServiceBusClient _client;
+
+    private readonly ServiceBusReceiver _receiver;
+
+    /// <inheritdoc />
+    public ServiceBusReceivedMessage Message { get; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="receiver"></param>
+    public ServiceBusReceivedMessageContext(ServiceBusClient client, ServiceBusReceiver receiver)
+    {
+        _client = client;
+        _receiver = receiver;
+    }
+
+    /// <inheritdoc />
+    public ServiceBusSender CreateMessageSender(ServiceBusEntityDescription description)
+        => _client.CreateSender(description.QueueName ?? description.TopicName);
+
+
+    /// <inheritdoc />
+    public async Task DeadLetterMessageAsync(ServiceBusReceivedMessage message, string reason,
+        CancellationToken cancellationToken)
+    {
+        await _receiver.DeadLetterMessageAsync(
+                message,
+                reason,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task CompleteMessageAsync(ServiceBusReceivedMessage message, CancellationToken cancellationToken)
+    {
+        await _receiver.CompleteMessageAsync(message, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task AbandonMessageAsync(ServiceBusReceivedMessage message, IDictionary<string, object> propertiesToModify, CancellationToken cancellationToken)
+    {
+        await _receiver.AbandonMessageAsync(message, propertiesToModify, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/ServiceBusReceivedMessageContextProcessor.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/ServiceBusReceivedMessageContextProcessor.cs
@@ -1,0 +1,80 @@
+﻿using Moosesoft.Azure.Messaging.ServiceBus.FailurePolicies;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus;
+
+/// <inheritdoc />
+internal class ServiceBusReceivedMessageContextProcessor : IMessageContextProcessor
+{
+    private readonly IFailurePolicy _failurePolicy;
+    private readonly ServiceBusEntityDescription _description;
+    private readonly IMessageProcessor _messageProcessor;
+    private readonly Func<Exception, bool> _shouldComplete;
+
+    /// <inheritdoc />
+    public string Name { get; }
+
+    public ServiceBusReceivedMessageContextProcessor(
+        ServiceBusEntityDescription description,
+        IMessageProcessor messageProcessor,
+        IFailurePolicy failurePolicy = null,
+        Func<Exception, bool> shouldComplete = null,
+        string name = "default")
+    {
+        _description = description ?? throw new ArgumentNullException(nameof(description));
+        _messageProcessor = messageProcessor ?? throw new ArgumentNullException(nameof(messageProcessor));
+        _failurePolicy = failurePolicy ?? new AbandonMessageFailurePolicy();
+        _shouldComplete = shouldComplete;
+        Name = name;
+
+        _failurePolicy.SetEntityDescription(description);
+    }
+
+    /// <inheritdoc />
+    public async Task ProcessMessageContextAsync(IServiceBusReceivedMessageContext messageContext, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _messageProcessor.ProcessMessageAsync(messageContext.Message, cancellationToken).ConfigureAwait(false);
+
+
+            await messageContext
+                .CompleteMessageAsync(messageContext.Message, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            if (await TryCompleteOnExceptionAsync(messageContext, exception, cancellationToken) ||
+                await TryAbandonOnExceptionAsync(messageContext, exception, cancellationToken))
+            {
+                return;
+            }
+
+            await _failurePolicy.HandleFailureAsync(messageContext, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task<bool> TryCompleteOnExceptionAsync(IServiceBusReceivedMessageContext messageContext, Exception exception, CancellationToken cancellationToken)
+    {
+        if (_shouldComplete == null || !_shouldComplete(exception)) return false;
+
+        await messageContext
+            .CompleteMessageAsync(messageContext.Message, cancellationToken)
+            .ConfigureAwait(false);
+
+        return true;
+    }
+
+    private async Task<bool> TryAbandonOnExceptionAsync(IServiceBusReceivedMessageContext messageContext, Exception exception, CancellationToken cancellationToken)
+    {
+        if (_failurePolicy.CanHandle(exception)) return false;
+
+        await messageContext
+            .AbandonMessageAsync(messageContext.Message, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        return true;
+    }
+}

--- a/src/Moosesoft.Azure.Messaging.ServiceBus/ServiceBusReceivedMessageExtensions.cs
+++ b/src/Moosesoft.Azure.Messaging.ServiceBus/ServiceBusReceivedMessageExtensions.cs
@@ -1,0 +1,13 @@
+﻿using Azure.Messaging.ServiceBus;
+
+namespace Moosesoft.Azure.Messaging.ServiceBus;
+
+internal static class ServiceBusReceivedMessageExtensions
+{
+    public static int GetRetryCount(this ServiceBusReceivedMessage message) =>
+        message.ApplicationProperties.TryGetValue(Constants.RetryCountKey, out var count) && count != null
+            ? (int)count
+            : 0;
+
+    public static int GetDeliveryCount(this ServiceBusReceivedMessage message) => message.DeliveryCount;
+}

--- a/src/Moosesoft.Azure.Webjobs.Extensions.ServiceBus/Moosesoft.Azure.Webjobs.Extensions.ServiceBus.csproj
+++ b/src/Moosesoft.Azure.Webjobs.Extensions.ServiceBus/Moosesoft.Azure.Webjobs.Extensions.ServiceBus.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RootNamespace>Moosesoft.Azure.Webjobs.Extensions.ServiceBus</RootNamespace>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<LangVersion>latest</LangVersion>
+		<Version>1.0.0-preview1</Version>
+		<Authors>Marty Mathis</Authors>
+		<Company />
+		<Description>Provides support for advanced message processing scenarios using Microsoft Azure Service Bus, including retry with back off delay handling through failure policies.</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/gtmoose32/moosesoft-azure-messaging-servicebus</PackageProjectUrl>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/gtmoose32/moosesoft-azure-messaging-servicebus</RepositoryUrl>
+		<PackageTags>azure function webjob servicebus service bus retry delay backoff message queue topic</PackageTags>
+		<NeutralLanguage>en-US</NeutralLanguage>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<DocumentationFile Condition="'$(Configuration)'=='Release'">bin\Release\netstandard2.0\Moosesoft.Azure.Webjobs.Extensions.ServiceBus.xml</DocumentationFile>
+		<PackageReleaseNotes>
+		</PackageReleaseNotes>
+
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Moosesoft.Azure.Messaging.ServiceBus\Moosesoft.Azure.Messaging.ServiceBus.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.8.1" />
+	</ItemGroup>
+
+</Project>

--- a/src/Moosesoft.Azure.Webjobs.Extensions.ServiceBus/WebJobsServiceBusReceivedMessageContext.cs
+++ b/src/Moosesoft.Azure.Webjobs.Extensions.ServiceBus/WebJobsServiceBusReceivedMessageContext.cs
@@ -1,0 +1,60 @@
+﻿using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.WebJobs.ServiceBus;
+using Moosesoft.Azure.Messaging.ServiceBus;
+
+namespace Moosesoft.Azure.Webjobs.Extensions.ServiceBus;
+
+/// <summary>
+/// <see cref="IServiceBusReceivedMessageContext"/> implementation compatible for use with Microsoft.Azure.WebJobs and AzureFunctions
+/// which expose a <see cref="ServiceBusMessageActions"/> class for handling messages.
+/// </summary>
+public class WebJobsServiceBusReceivedMessageContext : IServiceBusReceivedMessageContext
+{
+
+    /// <inheritdoc />
+    public ServiceBusReceivedMessage Message { get; }
+
+
+    private readonly ServiceBusClient _client;
+    private readonly ServiceBusMessageActions _messageActions;
+
+    /// <inheritdoc />
+    public ServiceBusSender CreateMessageSender(ServiceBusEntityDescription description)
+        => _client.CreateSender(description.QueueName ?? description.TopicName);
+
+    /// <summary>
+    /// Creates a new <see cref="WebJobsServiceBusReceivedMessageContext"/>
+    /// </summary>
+    /// <param name="message"></param>
+    /// <param name="messageActions"></param>
+    /// <param name="client"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public WebJobsServiceBusReceivedMessageContext(ServiceBusReceivedMessage message, ServiceBusMessageActions messageActions, ServiceBusClient client)
+    {
+        Message = message ?? throw new ArgumentNullException(nameof(message));
+        _messageActions = messageActions ?? throw new ArgumentNullException(nameof(messageActions));
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <inheritdoc />
+    public async Task DeadLetterMessageAsync(ServiceBusReceivedMessage messageContextMessage, string reason, CancellationToken cancellationToken)
+    {
+        await _messageActions.DeadLetterMessageAsync(messageContextMessage, reason, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task CompleteMessageAsync(ServiceBusReceivedMessage messageContextMessage, CancellationToken cancellationToken)
+    {
+        await _messageActions.CompleteMessageAsync(messageContextMessage, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task AbandonMessageAsync(ServiceBusReceivedMessage message, IDictionary<string, object>? propertiesToModify = default,
+        CancellationToken cancellationToken = default)
+    {
+        await _messageActions.AbandonMessageAsync(message, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
Added abstraction for `IServiceBusReceivedMessageContext` and moved WebJobs specific implementation to new project.

Moosesoft.Azure.Messaging.ServiceBus does not have any dependencies outside of ServiceBus and has a built-in `ServiceBusReceivedMessageContext` implementation using `ServiceBusReceiver`.

Moosesoft.Azure.Webjobs.Extensions.ServiceBus provides `WebJobsServiceBusReceivedMessageContext` which makes the library compatible with WebJobs (AzureFunctions).
